### PR TITLE
Remove event storage for unsupported entities

### DIFF
--- a/spring-cloud-stream-replication-starter/src/main/java/io/daniellavoie/spring/replication/ReplicationEvent.java
+++ b/spring-cloud-stream-replication-starter/src/main/java/io/daniellavoie/spring/replication/ReplicationEvent.java
@@ -27,8 +27,8 @@ public class ReplicationEvent {
 
 	}
 
-	public ReplicationEvent(long replicationEventId, LocalDateTime timestamp, String objectClass, EventType eventType, String source,
-			String payload) {
+	public ReplicationEvent(long replicationEventId, LocalDateTime timestamp, String objectClass, EventType eventType,
+			String source, String payload) {
 		setReplicationEventId(replicationEventId);
 		setTimestamp(timestamp);
 		setObjectClass(objectClass);
@@ -87,5 +87,12 @@ public class ReplicationEvent {
 
 	public void setPayload(String payload) {
 		this.payload = payload;
+	}
+
+	@Override
+	public String toString() {
+		return "ReplicationEvent [replicationEventId=" + replicationEventId + ", timestamp=" + timestamp
+				+ ", objectClass=" + objectClass + ", eventType=" + eventType + ", source=" + source + ", payload="
+				+ payload + "]";
 	}
 }

--- a/spring-cloud-stream-replication-starter/src/main/java/io/daniellavoie/spring/replication/ReplicationEventServiceImpl.java
+++ b/spring-cloud-stream-replication-starter/src/main/java/io/daniellavoie/spring/replication/ReplicationEventServiceImpl.java
@@ -56,13 +56,17 @@ public class ReplicationEventServiceImpl implements ReplicationEventService {
 	@StreamListener(ReplicationSink.INPUT)
 	public void processEvent(ReplicationEvent replicationEvent) {
 		LOGGER.trace("Received a replication event.");
-		
-		replicationEvent = replicationEventRepository.save(replicationEvent);
 
 		ReplicationService<?> replicationService = replicationServices.get(replicationEvent.getObjectClass());
 
 		if (replicationService != null) {
+			replicationEvent = replicationEventRepository.save(replicationEvent);
+
 			if (!replicationService.skipEventProcessing()) {
+				if (LOGGER.isTraceEnabled()) {
+					LOGGER.trace("Processing " + replicationEvent + ".");
+				}
+
 				if (EventType.UPDATE.equals(replicationEvent.getEventType())) {
 					replicationService.convertAndProcessUpdateEvent(replicationEvent);
 				} else {
@@ -72,7 +76,8 @@ public class ReplicationEventServiceImpl implements ReplicationEventService {
 				LOGGER.trace("Skipping replication event processing.");
 			}
 		} else {
-			LOGGER.trace("Could not find a replication service for class " + replicationEvent.getObjectClass() + " Ignoring notification.");
+			LOGGER.trace("Could not find a replication service for class " + replicationEvent.getObjectClass()
+					+ " Ignoring notification.");
 		}
 	}
 

--- a/spring-cloud-stream-replication-starter/src/test/java/io/daniellavoie/spring/replication/ProcessUpdateEventTest.java
+++ b/spring-cloud-stream-replication-starter/src/test/java/io/daniellavoie/spring/replication/ProcessUpdateEventTest.java
@@ -72,7 +72,7 @@ public class ProcessUpdateEventTest extends ReplicationServiceTest {
 
 		replicationEventService.processEvent(replicationEvent);
 
-		Mockito.verify(replicationEventRepository).save(Mockito.any());
+		Mockito.verify(replicationEventRepository, Mockito.never()).save(Mockito.any());
 		Mockito.verify(testMessageRepository, Mockito.never()).save(Mockito.any());
 	}
 
@@ -113,8 +113,8 @@ public class ProcessUpdateEventTest extends ReplicationServiceTest {
 	public void testWithoutConfiguredReplicationService() throws JsonProcessingException {
 		setup();
 
-		ReplicationEventService replicationEventService = new ReplicationEventServiceImpl(new ReplicationConfig(), replicationEventRepository,
-				Optional.empty());
+		ReplicationEventService replicationEventService = new ReplicationEventServiceImpl(new ReplicationConfig(),
+				replicationEventRepository, Optional.empty());
 
 		ReplicationEvent replicationEvent = new ReplicationEvent(1, LocalDateTime.now(), TestMessage.class.getName(),
 				EventType.UPDATE, "default",
@@ -122,7 +122,7 @@ public class ProcessUpdateEventTest extends ReplicationServiceTest {
 
 		replicationEventService.processEvent(replicationEvent);
 
-		Mockito.verify(replicationEventRepository).save(Mockito.any());
+		Mockito.verify(replicationEventRepository, Mockito.never()).save(Mockito.any());
 		Mockito.verify(testMessageRepository, Mockito.never()).save(Mockito.any());
 	}
 }


### PR DESCRIPTION
* Messages consumed with an entityClass that
  is not supported by the application won't be persisted
  in the event store anymore.